### PR TITLE
fix issue with the kubectl create secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,15 @@ helm template \
 # generate a random password
 PASSWORD=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
 
+# Create namespace openfaas and openfaas-fn
+kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+
 kubectl -n openfaas create secret generic basic-auth \
 --from-literal=basic-auth-user=admin \
 --from-literal=basic-auth-password="$PASSWORD"
 
 echo $PASSWORD > password.txt
 
-kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
 kubectl apply -f ./manifests/openfaas/templates/
 ```
 


### PR DESCRIPTION
When running the commands in order I got an error on the 
$ kubectl -n openfaas create secret generic basic-auth \
> --from-literal=basic-auth-user=admin \
> --from-literal=basic-auth-password="$PASSWORD"
Error from server (NotFound): namespaces "openfaas" not found

So I guess we first need to run this command
$ kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml

And it worked the next time. So I just fixed the order of the commands. 